### PR TITLE
Some changes from Genie side

### DIFF
--- a/bootleg/utils/eval_utils.py
+++ b/bootleg/utils/eval_utils.py
@@ -549,8 +549,10 @@ def write_data_labels_hlp(args):
             aliases = line['aliases']
             sent_idx = line['sent_idx_unq']
             qids = []
+            cand_qids = []
             ctx_emb_ids = []
             entity_ids = []
+            cand_entity_ids = []
             probs = []
             cands = []
             cand_probs = []
@@ -566,17 +568,23 @@ def write_data_labels_hlp(args):
                 cand_prob = filt_emb_data_global[emb_idx]['final_loss_cand_probs']
                 pred_cand = filt_emb_data_global[emb_idx]['final_loss_pred']
                 eid = entity_cands_eid[al_idx][pred_cand]
+                entity_ids.append(eid)
+                cand_entity_ids.append(entity_cands_eid[al_idx])
                 qid = entity_cands_qid[al_idx][pred_cand]
                 qids.append(qid)
+                cand_qids.append(entity_cands_qid[al_idx])
                 probs.append(prob)
                 cands.append(list(entity_cands_qid[al_idx]))
                 cand_probs.append(list(cand_prob))
-                entity_ids.append(eid)
+                
             line['qids'] = qids
+            line['cand_qids'] = cand_qids
             line['probs'] = probs
             line['cands'] = cands
             line['cand_probs'] = cand_probs
             line['entity_ids'] = entity_ids
+            line['cand_entity_ids'] = cand_entity_ids
+
             if dump_embs_global:
                 line['ctx_emb_ids'] = ctx_emb_ids
             f_out.write(ujson.dumps(line) + "\n")

--- a/bootleg/utils/eval_utils.py
+++ b/bootleg/utils/eval_utils.py
@@ -554,7 +554,6 @@ def write_data_labels_hlp(args):
             entity_ids = []
             cand_entity_ids = []
             probs = []
-            cands = []
             cand_probs = []
             entity_cands_qid = map_aliases_to_candidates(train_in_candidates_global, entity_dump_global, aliases)
             # eid is entity id
@@ -571,9 +570,7 @@ def write_data_labels_hlp(args):
                 
                 # sort predicted cands based on cand_probs
                 packed_list = zip(cand_prob, entity_cands_eid[al_idx], entity_cands_qid[al_idx])
-                
                 packed_list_sorted = sorted(packed_list, key=lambda tup: tup[0], reverse=True)
-
                 cand_prob, cand_entity_id, cand_qid = list(zip(*packed_list_sorted))
                 
                 eid = entity_cands_eid[al_idx][pred_cand]
@@ -583,17 +580,15 @@ def write_data_labels_hlp(args):
                 qids.append(qid)
                 cand_qids.append(cand_qid)
                 probs.append(prob)
-                cands.append(list(entity_cands_qid[al_idx]))
                 cand_probs.append(list(cand_prob))
                 
             line['qids'] = qids
-            line['cand_qids'] = cand_qids
             line['probs'] = probs
-            line['cands'] = cands
-            line['cand_probs'] = cand_probs
             line['entity_ids'] = entity_ids
+            line['cands'] = cand_qids
+            line['cand_probs'] = cand_probs
             line['cand_entity_ids'] = cand_entity_ids
-
+            
             if dump_embs_global:
                 line['ctx_emb_ids'] = ctx_emb_ids
             f_out.write(ujson.dumps(line) + "\n")

--- a/bootleg/utils/eval_utils.py
+++ b/bootleg/utils/eval_utils.py
@@ -564,15 +564,24 @@ def write_data_labels_hlp(args):
                 assert sent_idx_key in sent_idx_map_global, f'Dumped prediction data does not match data file. Can not find {sent_idx} - {al_idx}'
                 emb_idx = sent_idx_map_global[sent_idx_key][0][0]
                 ctx_emb_ids.append(emb_idx)
+
                 prob = filt_emb_data_global[emb_idx]['final_loss_prob']
                 cand_prob = filt_emb_data_global[emb_idx]['final_loss_cand_probs']
                 pred_cand = filt_emb_data_global[emb_idx]['final_loss_pred']
+                
+                # sort predicted cands based on cand_probs
+                packed_list = zip(cand_prob, entity_cands_eid[al_idx], entity_cands_qid[al_idx])
+                
+                packed_list_sorted = sorted(packed_list, key=lambda tup: tup[0], reverse=True)
+
+                cand_prob, cand_entity_id, cand_qid = list(zip(*packed_list_sorted))
+                
                 eid = entity_cands_eid[al_idx][pred_cand]
                 entity_ids.append(eid)
-                cand_entity_ids.append(entity_cands_eid[al_idx])
+                cand_entity_ids.append(cand_entity_id)
                 qid = entity_cands_qid[al_idx][pred_cand]
                 qids.append(qid)
-                cand_qids.append(entity_cands_qid[al_idx])
+                cand_qids.append(cand_qid)
                 probs.append(prob)
                 cands.append(list(entity_cands_qid[al_idx]))
                 cand_probs.append(list(cand_prob))

--- a/bootleg/utils/logging_utils.py
+++ b/bootleg/utils/logging_utils.py
@@ -27,19 +27,20 @@ def create_logger(args, mode):
     logger.propagate = False
     log_name = get_log_name(args, mode)
     if not os.path.exists(log_name): os.system("touch " + log_name)
-    if not logger.hasHandlers():
-        formatter = logging.Formatter('%(asctime)s %(message)s')
-        fh = logging.FileHandler(log_name, mode='w' if mode == 'train' else 'a')
-        fh.setFormatter(formatter)
-        logger.addHandler(fh)
-        # only print the stream for the first GPU
-        if args.run_config.gpu == 0:
-            sh = logging.StreamHandler()
-            sh.setFormatter(formatter)
-            logger.addHandler(sh)
-    else:
-        print('Something went wrong in the logger')
-        exit()
+    
+    if logger.hasHandlers():
+        logger.handlers = []
+        
+    formatter = logging.Formatter('%(asctime)s %(message)s')
+    fh = logging.FileHandler(log_name, mode='w' if mode == 'train' else 'a')
+    fh.setFormatter(formatter)
+    logger.addHandler(fh)
+    # only print the stream for the first GPU
+    if args.run_config.gpu == 0:
+        sh = logging.StreamHandler()
+        sh.setFormatter(formatter)
+        logger.addHandler(sh)
+
     return logger
 
 def get_logger(args):

--- a/bootleg/utils/train_utils.py
+++ b/bootleg/utils/train_utils.py
@@ -26,7 +26,10 @@ def setup_run_folders(args, mode):
     return
 
 def get_save_folder(run_args):
-    save_folder = os.path.join(run_args.save_dir, run_args.timestamp)
+    if run_args.timestamp != 'None':
+        save_folder = os.path.join(run_args.save_dir, run_args.timestamp)
+    else:
+        save_folder = run_args.save_dir
     os.makedirs(save_folder, exist_ok=True)
     return save_folder
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,9 @@ pandas==0.25.3
 pytest==5.3.0
 seaborn==0.9.0
 scikit_learn==0.22
-scipy==1.3.1
 spacy==2.3.5
+scipy~=1.3.1
+seaborn==0.9.0
 tabulate==0.8.7
 tagme==0.1.3
 tensorboard==2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ argh==0.26.2
 ipdb==0.12.3
 jsonlines==1.2.0
 marisa_trie==0.7.5
-matplotlib==3.1.1
 mock==3.0.5
 networkx==2.4
 nltk==3.4.5
@@ -10,11 +9,9 @@ notebook==6.0.3
 numpy==1.17.3
 pandas==0.25.3
 pytest==5.3.0
-seaborn==0.9.0
 scikit_learn==0.22
 spacy==2.3.5
 scipy~=1.3.1
-seaborn==0.9.0
 tabulate==0.8.7
 tagme==0.1.3
 tensorboard==2.4

--- a/test/test_emb_extraction.py
+++ b/test/test_emb_extraction.py
@@ -279,20 +279,22 @@ class EmbeddingExtractionTest(unittest.TestCase):
                 'aliases': ['a', 'b'],
                 'qids' : ["Q4", "Q1"],
                 'probs' : [0.9, 0.9],
-                'cands' : [["Q1", "Q4"], ["Q2", "Q1"]],
-                'cand_probs' : [[0.1, 0.9], [0.1, 0.9]],
+                'cands' : [["Q4", "Q1"], ["Q1", "Q2"]],
+                'cand_probs' : [[0.9, 0.1], [0.9, 0.1]],
                 'entity_ids' : [4, 1],
-                'ctx_emb_ids' : [0, 1]
+                'ctx_emb_ids' : [0, 1],
+                'cand_entity_ids': [[4, 1], [1, 2]]
             },
             {
                 'sent_idx_unq': 1,
                 'aliases': ['c', 'd', 'e', 'f', 'g'],
                 'qids' : ["Q1", "Q4", "Q4", "Q1", "Q2"],
                 'probs' : [0.9, 0.9, 0.9, 0.9, 0.9],
-                'cands' : [["Q1", "Q2"], ["Q4", "Q3"], ["Q1", "Q4"], ["Q2", "Q1"], ["Q1", "Q2"]],
-                'cand_probs' : [[0.9, 0.1], [0.9, 0.1], [0.1, 0.9], [0.1, 0.9], [0.1, 0.9]],
+                'cands' : [["Q1", "Q2"], ["Q4", "Q3"], ["Q4", "Q1"], ["Q1", "Q2"], ["Q2", "Q1"]],
+                'cand_probs' : [[0.9, 0.1], [0.9, 0.1], [0.9, 0.1], [0.9, 0.1], [0.9, 0.1]],
                 'entity_ids' : [1, 4, 4, 1, 2],
-                'ctx_emb_ids' : [2, 3, 4, 5, 6]
+                'ctx_emb_ids' : [2, 3, 4, 5, 6],
+                'cand_entity_ids': [[1, 2], [4, 3], [4, 1], [1, 2], [2, 1]]
             }
         ]
 


### PR DESCRIPTION
- Sort candidate prediction based on their probabilities so we can avoid doing the sorting in other processes that use the output
- Fix error in logging_utils when the same logger is initiated again
- Unpin scipy version so pip can decide best version given other dependencies. In general, I think it would be better if you could relax the package version in requirements.txt and let pip choose the latest version that agrees with other dependencies.