### PR TITLE
feat(annotator, datasets, init): fixed log in annotator, use_exact_pa…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Unreleased_
 -------------------
- 
+Added
+^^^^^^^
+* ``data_config.print_examples_prep`` flag to toggle data example printing during data prep
+
+Fixed
+^^^^^^^
+* Fixed readthedocs so the BootlegAnnotator was loaded correctly
+* Fixed logging in BootlegAnnotator
+* Fixed ``use_exact_path`` argument in Emmental
+
 1.0.0 - 2020-02-15
 -------------------
 We did a major rewrite of our entire codebase and moved to using `Emmental <https://github.com/SenWu/Emmental>`_ for training. Emmental allows for each multi-task training, FP16, and support for both DataParallel and DistributedDataParallel.

--- a/bootleg/_version.py
+++ b/bootleg/_version.py
@@ -1,2 +1,2 @@
 """Bootleg version."""
-__version__ = "1.0.0"
+__version__ = "1.0.0dev1"

--- a/bootleg/datasets/dataset.py
+++ b/bootleg/datasets/dataset.py
@@ -503,6 +503,7 @@ def convert_examples_to_features_and_save(
                 "max_seq_len": data_config.max_seq_len,
                 "train_in_candidates": data_config.train_in_candidates,
                 "max_aliases": data_config.max_aliases,
+                "pred_examples": data_config.print_examples_prep,
             }
         )
         offset += files_and_counts[in_file_name]
@@ -558,7 +559,7 @@ def convert_examples_to_features_and_save_hlp(input_args):
     save_file_offset = input_args["save_file_offset"]
     ex_print_mod = input_args["ex_print_mod"]
     guid_dtype = input_args["guid_dtype"]
-    is_bert = input_args["is_bert"]
+    print_examples = input_args["pred_examples"]
     max_aliases = input_args["max_aliases"]
     max_seq_len = input_args["max_seq_len"]
     split = input_args["split"]
@@ -735,7 +736,8 @@ def convert_examples_to_features_and_save_hlp(input_args):
                 + "\n"
             )
             output_str += f"guid:                            {feature.guid}" + "\n"
-            print(output_str)
+            if print_examples:
+                print(output_str)
     mmap_file_global.flush()
     mmap_label_file_global.flush()
     return total_saved_features

--- a/bootleg/embeddings/entity_embs.py
+++ b/bootleg/embeddings/entity_embs.py
@@ -72,9 +72,9 @@ class LearnedEntityEmb(EntityEmb):
         ), f"LearnedEntityEmb must have learned_embedding_size in args"
         self.learned_embedding_size = emb_args.learned_embedding_size
 
-        # Set sparsity based on optimizer. The None optimizer is Bootleg's SparseDenseAdam
+        # Set sparsity based on optimizer and fp16. The None optimizer is Bootleg's SparseDenseAdam. If fp16 is True, must use dense.
         optimiz = main_args.learner_config.optimizer_config.optimizer
-        if optimiz in [None, "sparse_adam"]:
+        if optimiz in [None, "sparse_adam"] and main_args.learner_config.fp16 is False:
             sparse = True
         else:
             sparse = False

--- a/bootleg/end2end/bootleg_annotator.py
+++ b/bootleg/end2end/bootleg_annotator.py
@@ -213,8 +213,12 @@ class BootlegAnnotator(object):
         )
         self.config.model_config.device = device
 
+        log_level = logging.getLevelName(self.config["run_config"]["log_level"].upper())
         emmental.init(
-            log_dir=self.config["meta_config"]["log_path"], config=self.config
+            log_dir=self.config["meta_config"]["log_path"],
+            config=self.config,
+            use_exact_log_path=self.config["meta_config"]["use_exact_log_path"],
+            level=log_level,
         )
 
         logger.debug("Reading entity database")

--- a/bootleg/layers/alias_to_ent_encoder.py
+++ b/bootleg/layers/alias_to_ent_encoder.py
@@ -73,6 +73,7 @@ class AliasEntityTable(nn.Module):
             prep_dir,
             f"alias2entity_table_{alias_str}_InC{int(data_config.train_in_candidates)}.pt",
         )
+        log_rank_0_debug(logger, f"Looking for alias table in {prep_file}")
         if not data_config.overwrite_preprocessed_data and os.path.exists(prep_file):
             log_rank_0_debug(logger, f"Loading alias table from {prep_file}")
             start = time.time()

--- a/bootleg/run.py
+++ b/bootleg/run.py
@@ -95,6 +95,7 @@ def setup(config, run_config_path=None):
     emmental.init(
         log_dir=config["meta_config"]["log_path"],
         config=config,
+        use_exact_log_path=config["meta_config"]["use_exact_log_path"],
         local_rank=config.learner_config.local_rank,
         level=log_level,
     )

--- a/bootleg/utils/classes/dotted_dict.py
+++ b/bootleg/utils/classes/dotted_dict.py
@@ -78,7 +78,7 @@ class DottedDict(dict):
         """Replace the space characters on the key with _ to make valid
         attrs."""
         key = str(key)
-        allowed = string.ascii_letters + string.digits + "_"
+        allowed = string.ascii_letters + string.digits + "_" + "/"
         # Replace spaces with _
         if " " in key:
             key = key.replace(" ", "_")

--- a/bootleg/utils/parser/bootleg_args.py
+++ b/bootleg/utils/parser/bootleg_args.py
@@ -74,6 +74,7 @@ config_args = {
         "max_seq_len": (100, "max token length sentences"),
         "max_aliases": (10, "max aliases per sentence"),
         "overwrite_preprocessed_data": (False, "overwrite preprocessed data"),
+        "print_examples_prep": (False, "whether to print examples during prep or not"),
         "type_prediction": {
             "use_type_pred": (False, "whether to add type prediction or not"),
             "file": (

--- a/bootleg/utils/parser/emm_parse_args.py
+++ b/bootleg/utils/parser/emm_parse_args.py
@@ -177,7 +177,7 @@ def parse_args(parser: Optional[ArgumentParser] = None) -> Tuple[ArgumentParser,
     learner_config.add_argument(
         "--emmental.online_eval",
         type=str2bool,
-        default=True,
+        default=False,
         help="Whether to perform online evaluation",
     )
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ copyright = "2021, Laurel Orr and Megan Leszczynski"
 author = "Laurel Orr and Megan Leszczynski"
 
 # The full version, including alpha/beta/rc tags
-release = "v0.0.2"
+release = "v1.0.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="bootleg",
-    version="1.0.0",
+    version="1.0.0dev1",
     description="Bootleg NED System",
     packages=find_packages(),
     url="https://github.com/HazyResearch/bootleg",


### PR DESCRIPTION
…th, example print flag

Fixed logger in Annotator class.
Fixed use exact path.
Added flag to print examples in dataset.
Fixed dotted dict to allow for saving best scoring model.
Fixed load spacy_sm_model for mention_extraction to work with ReadTheDocs
Changed default emmental arg to online_eval to be False (better memory)